### PR TITLE
refactor(erc-792): arbitration to arbitrator

### DIFF
--- a/src/erc-792.md
+++ b/src/erc-792.md
@@ -1,5 +1,5 @@
 title: ERC 792
-subtitle: The standard for Arbitra(tion/ble) smart contracts.
+subtitle: The standard for Arbitra(tor/ble) smart contracts.
 class: animation-fade
 layout: true
 


### PR DESCRIPTION
There are arbitrator and arbitrable contracts. Should we say **Arbitra(tor/ble)** instead of **Arbitra(tion/ble)** for consistency?